### PR TITLE
adds error styling linkage for form base errors

### DIFF
--- a/app/javascript/packs/tab_nav.js
+++ b/app/javascript/packs/tab_nav.js
@@ -10,7 +10,7 @@ isLastTab = function(tab) {
   if (tab.next().length == 0) {
     return true;
   } else {
-    return false; 
+    return false;
   }
 }
 
@@ -21,6 +21,14 @@ $(document).ready(function() {
       $(this).addClass("has-error");
     }
   });
+
+  $("#error-body ul li").each((i, element) => {
+    let panel_href_value = $(element).data('target-nav-panel');
+    if (panel_href_value !== undefined) {
+      $(`nav > .nav-link[href='#${panel_href_value}']`).addClass('has-error');
+    }
+  });
+
 }).on('click', '.next-prev-nav', function(e) {
   e.preventDefault();
   currentTabLink = $(".nav-link.active");
@@ -32,8 +40,12 @@ $(document).ready(function() {
 }).on('show.bs.tab hide.bs.tab', 'a.nav-link', function(e) {
   if (isFirstTab($(this))) {
     $('#prev-tab').toggleClass('visibility-hidden');
-  } 
+  }
   if (isLastTab($(this))) {
     $('#next-tab').toggleClass('visibility-hidden');
   }
+});
+
+$(document).on('change', '#error-body', () => {
+
 });

--- a/app/models/reimbursement_request.rb
+++ b/app/models/reimbursement_request.rb
@@ -96,6 +96,6 @@ class ReimbursementRequest < ApplicationRecord
   end
 
   def includes_travel_city
-    errors.add(:base, 'Must have at least one city travelled in the itinerary.') if travel_cities.empty? || travel_cities.all?(&:marked_for_destruction?)
+    errors.add(:base, 'Must have at least one city travelled in the itinerary.', target_nav_panel_href: 'itinerary_panel') if travel_cities.empty? || travel_cities.all?(&:marked_for_destruction?)
   end
 end

--- a/app/views/reimbursement_requests/_form_error.html.erb
+++ b/app/views/reimbursement_requests/_form_error.html.erb
@@ -6,11 +6,12 @@
       </div>
       <div class="panel-body" id="error-body">
         <ul>
-          <% obj.errors.messages[:base].each do |msg| %>
-            <li><%= msg %></li>
+          <% obj.errors.details[:base].each do |e| %>
+            <li data-target-nav-panel="<%= e[:target_nav_panel_href] || '' %>"><%= e[:error] %></li>
           <% end %>
         </ul>
       </div>
     </div>
   </div>
 <% end %>
+<%= console %>


### PR DESCRIPTION
gives us the ability to target form nav panels for adding error styling related to these types of "base" errors

![screen shot 2017-08-31 at 11 15 29 am](https://user-images.githubusercontent.com/32885/29938489-c229e2fe-8e3d-11e7-921b-b7f25a4ab0c1.png)
